### PR TITLE
editor-common-lib to prevent duplicate draft versions

### DIFF
--- a/packages/editor-common/web/src/index.js
+++ b/packages/editor-common/web/src/index.js
@@ -116,7 +116,5 @@ export {
   RawDraftContentState,
   EditorChangeType,
   convertFromHTML,
-} from 'draft-js';
-
-import DraftOffsetKey from 'draft-js/lib/DraftOffsetKey';
-export { DraftOffsetKey };
+  DraftOffsetKey,
+} from './lib/draftExports';

--- a/packages/editor-common/web/src/lib/draftExports.js
+++ b/packages/editor-common/web/src/lib/draftExports.js
@@ -1,0 +1,22 @@
+export {
+  convertToRaw,
+  getVisibleSelectionRect,
+  convertFromRaw,
+  EditorState,
+  SelectionState,
+  DefaultDraftBlockRenderMap,
+  Modifier,
+  RichUtils,
+  KeyBindingUtil,
+  genKey,
+  ContentBlock,
+  BlockMapBuilder,
+  AtomicBlockUtils,
+  ContentState,
+  RawDraftContentState,
+  EditorChangeType,
+  convertFromHTML,
+} from 'draft-js';
+
+import DraftOffsetKey from 'draft-js/lib/DraftOffsetKey';
+export { DraftOffsetKey };

--- a/packages/editor/web/src/lib/editorStateConversion.js
+++ b/packages/editor/web/src/lib/editorStateConversion.js
@@ -1,4 +1,8 @@
-import { convertFromRaw as fromRaw, convertToRaw as toRaw, EditorState } from 'draft-js';
+import {
+  convertFromRaw as fromRaw,
+  convertToRaw as toRaw,
+  EditorState,
+} from 'wix-rich-content-editor-common/dist/lib/draftExports';
 import { version } from '../../package.json';
 
 const addVersion = (obj, version) => {


### PR DESCRIPTION
editor consume this editor-common lib instead of draft itself