### PR TITLE
Convert from HTML

### DIFF
--- a/examples/storybook/package.json
+++ b/examples/storybook/package.json
@@ -30,6 +30,7 @@
     "@testing-library/react": "^9.4.0",
     "babel-jest": "^25.1.0",
     "classnames": "^2.0.0",
+    "draft-js-import-html": "^1.4.1",
     "jest": "^26.0.1",
     "jest-yoshi-preset": "4.31.0",
     "lint-staged": "^7.2.2",

--- a/examples/storybook/stories/TestCase/index.js
+++ b/examples/storybook/stories/TestCase/index.js
@@ -14,6 +14,7 @@ import GroupsStory from './GroupsStory';
 import NormalizerStory from './NormalizerStory';
 import ExternalUndoStory from './ExternalUndoStory';
 import ButtonsTest from './ButtonsTest';
+import HTMLConvertor from './HTMLConvertor';
 
 storiesOf('Test Cases')
   .add('Groups', GroupsStory)
@@ -28,4 +29,5 @@ storiesOf('Test Cases')
   .add('Blog Lefties', BlogLefties)
   .add('HTML Instagram Height', HTMLPluginStory)
   .add('Max Height', MaxHeight)
-  .add('Buttons Test', ButtonsTest);
+  .add('Buttons Test', ButtonsTest)
+  .add('HTML Convert', HTMLConvertor);


### PR DESCRIPTION
I tests the draft-html-import for FAQ to see whether it's basically working
in storybook example (Test Cases > HTML convert) it fails with: Invariant Violation: block is not a BlockNode

I believe we need to support it from within so it will use @wix/draft-js instead of draft-js to maker it work

on top of that we need to see what's the behavior with images/video etc