### PR TITLE
[RCE] Return the result of handleBeforeInput callback when present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
     Click to see more.
   </summary>
 
-
+  ### :home: Internal
+- `rce`
+  - [#1577](https://github.com/wix-incubator/rich-content/pull/1577) Return the result of handleBeforeInput callback when present
+  
   </details>
 <hr/>
 

--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.jsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.jsx
@@ -465,13 +465,17 @@ class RichContentEditor extends Component {
   };
 
   handleBeforeInput = (chars, editorState, timestamp) => {
-    this.props.handleBeforeInput?.(chars, editorState, timestamp);
+    const handled = this.props.handleBeforeInput?.(chars, editorState, timestamp);
 
     const blockType = getBlockType(this.state.editorState);
     if (blockType === 'atomic') {
       // fixes space click on atomic blocks deletion bug.
       // in general, disables any input click on atomic blocks
       return 'handled';
+    }
+
+    if (handled) {
+      return handled;
     }
   };
 


### PR DESCRIPTION
We use the prop callback to apply char limiting to the editor, for this to work we need the handler to return the result when we set it.