### PR TITLE
[editor] fix: convert <pre/> html tag to unstyled instead of converting to code-block type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 ### :bug: Bug Fix
 - `viewer`
   - [#1780](https://github.com/wix-incubator/rich-content/pull/1780) preview interaction block wrapping logic refactored
+- `editor`
+  - [#1796](https://github.com/wix-incubator/rich-content/pull/1796) convert `<pre/>` html tag to `unstyled` instead of `code-block`
 
 ### :house: Internal
 - `editor`

--- a/packages/editor/web/src/RichContentEditor/utils/pasting/htmlToBlock.js
+++ b/packages/editor/web/src/RichContentEditor/utils/pasting/htmlToBlock.js
@@ -36,7 +36,7 @@ export const getBlockTypeOfElement = (elementTag, customHeadings) => {
 };
 
 const shouldConvertElementToBlock = type =>
-  ['li', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(type);
+  ['li', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'pre'].includes(type);
 
 const getDynamicStyles = (style = {}) => {
   if (!style.lineHeight && !style.paddingTop && !style.paddingBottom) {


### PR DESCRIPTION
Convert `<pre/>` html tag to `unstyled` type instead of `code-block` type.