### PR TITLE
[ricos-common] clean(theme API): "fontFamily" attr

### DIFF
--- a/packages/ricos-common/web/src/themeStrategy/generators/typography.spec.ts
+++ b/packages/ricos-common/web/src/themeStrategy/generators/typography.spec.ts
@@ -14,10 +14,6 @@ describe('Typography', () => {
       input: { wixTypography: wixTypographyTestCase },
       output: expectedOutput,
     },
-    {
-      input: { fontFamily: 'Arial', wixTypography: wixTypographyTestCase },
-      output: { fontFamily: 'Arial', ...expectedOutput },
-    },
   ];
 
   it('should return empty object if typography is empty / undefined', () => {
@@ -27,18 +23,8 @@ describe('Typography', () => {
     expect(cssVars2).toEqual({});
   });
 
-  it('should apply fontFamily', () => {
-    const cssVars = createTypography(mocks[2].input);
-    expect(cssVars).toStrictEqual(mocks[2].output);
-  });
-
   it('should apply wixTypography', () => {
     const cssVars = createTypography(mocks[3].input);
     expect(cssVars).toStrictEqual(mocks[3].output);
-  });
-
-  it('should apply fontFamily & wixTypography', () => {
-    const cssVars = createTypography(mocks[4].input);
-    expect(cssVars).toStrictEqual(mocks[4].output);
   });
 });

--- a/packages/ricos-common/web/src/themeStrategy/generators/typography.ts
+++ b/packages/ricos-common/web/src/themeStrategy/generators/typography.ts
@@ -19,7 +19,7 @@ export default function createTypography(typography?: RicosTheme['typography']):
   if (!typography) {
     return {};
   }
-  const { fontFamily, wixTypography } = typography;
+  const { wixTypography } = typography;
   const wixTypographyVars: CssVarsObject = wixTypography ? toVars(wixTypography) : {};
-  return Object.assign(wixTypographyVars, fontFamily && { fontFamily });
+  return wixTypographyVars;
 }


### PR DESCRIPTION
Removal of typography's "fontFamily" property.
Breaking Change.