### PR TITLE
[editor] fix: call updateEditorState when new editorState is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
     Click to see more.
   </summary>
 
+### :bug: Bug Fix
+- `editor`
+  - [#1938](https://github.com/wix-incubator/rich-content/pull/1938) call updateEditorState when new editorState is given (by passing `callOnChangeOnNewEditorState` = true prop)
+
 ## 8.11.2 (Dec 31, 2020)
 ### :bug: Bug Fix
 - `vertical-embed`

--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
@@ -147,6 +147,7 @@ export interface RichContentEditorProps extends PartialDraftEditorProps {
     updateEditorStateCallback: (editorState: EditorState) => void
   ) => DraftEditorProps['handleReturn'];
   tablePluginMenu?: boolean;
+  callOnChangeOnNewEditorState?: boolean;
   /** This is a legacy API, chagnes should be made also in the new Ricos Editor API **/
 }
 
@@ -497,7 +498,11 @@ class RichContentEditor extends Component<RichContentEditorProps, State> {
     }
     // TODO: new editor state should become initialContentState?
     if (nextProps.editorState && this.props.editorState !== nextProps.editorState) {
-      this.updateEditorState(nextProps.editorState);
+      if (this.props.callOnChangeOnNewEditorState) {
+        this.updateEditorState(nextProps.editorState);
+      } else {
+        this.setState({ editorState: nextProps.editorState });
+      }
     }
     if (this.props.theme !== nextProps.theme) {
       this.setState({ theme: nextProps.theme });

--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
@@ -497,7 +497,7 @@ class RichContentEditor extends Component<RichContentEditorProps, State> {
     }
     // TODO: new editor state should become initialContentState?
     if (nextProps.editorState && this.props.editorState !== nextProps.editorState) {
-      this.setState({ editorState: nextProps.editorState });
+      this.updateEditorState(nextProps.editorState);
     }
     if (this.props.theme !== nextProps.theme) {
       this.setState({ theme: nextProps.theme });


### PR DESCRIPTION
For OneApp,
When they pass us new editorState, and the editor is not focused, the `onChange` doesn't fire, the ref has dated content, and when consumer will use `getContent` & `getContentPromise`, dated content will return.