### PR TITLE
[editor] fix: convertToRaw when inner-rce contentState is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
     Click to see more.
   </summary>
 
+### :bug: Bug Fix
+- `editor`
+  - [#1973](https://github.com/wix/ricos/commit/1973) fix `convertToRaw` when inner-rce is undefined (only for Rce-on-Rce plugins)
 
 </details>
 <hr/>

--- a/packages/editor/web/lib/editorStateConversion.ts
+++ b/packages/editor/web/lib/editorStateConversion.ts
@@ -85,10 +85,12 @@ const entityFixersToRaw = [
     entityFixer: (entity: RawDraftEntity) => {
       const { pairs } = entity.data;
       entity.data.pairs = pairs.map((pair: Pair) => {
+        const title = pair.title?.getCurrentContent() || createEmptyContent();
+        const content = pair.content?.getCurrentContent() || createEmptyContent();
         return {
           key: pair.key,
-          title: toRaw(pair.title.getCurrentContent()),
-          content: toRaw(pair.content.getCurrentContent()),
+          title: toRaw(title),
+          content: toRaw(content),
         };
       });
     },
@@ -107,7 +109,8 @@ const convertTableConfigToRaw = config => {
   Object.entries(rows).forEach(([rowIndex, row]) => {
     newRows[rowIndex] = {};
     Object.entries(row.columns).forEach(([cellIndex, cell]) => {
-      const content = toRaw(cell.content.getCurrentContent());
+      const contentState = cell.content?.getCurrentContent() || createEmptyContent();
+      const content = toRaw(contentState);
       newRows[rowIndex].columns = {
         ...newRows[rowIndex].columns,
         [cellIndex]: { ...cell, content },
@@ -157,6 +160,7 @@ const convertFromRaw = rawState =>
   addVersion(fromRaw(entityMapDataFixer(rawState, entityFixersFromRaw)), rawState.VERSION);
 
 const createEmpty = () => addVersion(EditorState.createEmpty(), version);
+const createEmptyContent = () => createEmpty().getCurrentContent();
 const createWithContent = contentState =>
   addVersion(EditorState.createWithContent(contentState), contentState.VERSION);
 


### PR DESCRIPTION
This fix comes from Standalone, which uses RichContentEditor with onChange and update editorState with inner-rce contentState undefined (in initialization of table/accordion).