### PR TITLE
[inner-rce] fix: disabled toolbars in inner-rce when clicking on reac…

### DIFF
--- a/packages/editor/web/src/RichContentEditor/InnerRCE.jsx
+++ b/packages/editor/web/src/RichContentEditor/InnerRCE.jsx
@@ -60,6 +60,7 @@ class InnerRCE extends PureComponent {
       this.editorWrapper &&
       e.target &&
       !e.target.closest('[data-id=rich-content-editor-modal]') &&
+      !e.target.closest('[class=ReactModalPortal]') &&
       !this.editorWrapper.contains(e.target)
     ) {
       this.setState({ showToolbars: false });


### PR DESCRIPTION
…t-modal

<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
