### PR TITLE
WIP: Highlight and unhihglight buttons in the viewer for selections

### DIFF
--- a/examples/main/shared/viewer/Viewer.tsx
+++ b/examples/main/shared/viewer/Viewer.tsx
@@ -7,7 +7,7 @@ import getImagesData from 'wix-rich-content-fullscreen/libs/getImagesData';
 import Fullscreen from 'wix-rich-content-fullscreen';
 import 'wix-rich-content-fullscreen/dist/styles.min.css';
 import { IMAGE_TYPE } from 'wix-rich-content-plugin-image/viewer';
-import { TextSelectionToolbar, TwitterButton } from 'wix-rich-content-text-selection-toolbar';
+import { TextSelectionToolbar, TwitterButton, HighlightButton, UnhighlightButton } from 'wix-rich-content-text-selection-toolbar';
 import { GALLERY_TYPE } from 'wix-rich-content-plugin-gallery';
 const anchorTarget = '_top';
 const relValue = 'noreferrer';
@@ -114,7 +114,11 @@ export default class Viewer extends PureComponent<ExampleViewerProps, ExampleVie
           )}
           {!isMobile ? (
             <TextSelectionToolbar container={this.viewerRef.current}>
-              {selectedText => <TwitterButton selectedText={selectedText} />}
+              {selectedText => <>
+                <TwitterButton selectedText={selectedText} />
+                <HighlightButton />
+                <UnhighlightButton />
+              </>}
             </TextSelectionToolbar>
           ) : null}
         </div>

--- a/examples/storybook/stories/Toolbars/TextSelectionToolbar/TextSelectionViewer.tsx
+++ b/examples/storybook/stories/Toolbars/TextSelectionToolbar/TextSelectionViewer.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { RicosContent, RicosViewer } from 'ricos-viewer';
-import { TextSelectionToolbar, TwitterButton } from 'wix-rich-content-text-selection-toolbar';
+import { TextSelectionToolbar, TwitterButton, HighlightButton, UnhighlightButton } from 'wix-rich-content-text-selection-toolbar';
 
 class TextSelectionViewer extends Component<
   { content?: RicosContent },
@@ -14,7 +14,13 @@ class TextSelectionViewer extends Component<
       <div data-hook="viewer" style={{ position: 'relative', paddingTop: '8px' }} ref={this.setRef}>
         <RicosViewer content={content} />
         <TextSelectionToolbar container={this.state.containerRef}>
-          {selectedText => <TwitterButton selectedText={selectedText} />}
+          {selectedText => (
+            <>
+              <TwitterButton selectedText={selectedText} />
+              <HighlightButton />
+              <UnhighlightButton />
+            </>
+          )}
         </TextSelectionToolbar>
       </div>
     );

--- a/packages/text-selection-toolbar/web/src/HighlightButton.tsx
+++ b/packages/text-selection-toolbar/web/src/HighlightButton.tsx
@@ -1,0 +1,35 @@
+import React, { FunctionComponent } from 'react';
+import styles from '../statics/styles/viewer-inline-toolbar.rtlignore.scss';
+
+function highlightSelection() {
+  let range;
+  const sel = window.getSelection();
+
+  if (sel) {
+    range = sel.getRangeAt(0);
+  }
+
+  document.designMode = 'on';
+
+  if (range) {
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+  }
+
+  document.execCommand('BackColor', false, 'yellow');
+  document.designMode = 'off';
+}
+
+const HighlightButton: FunctionComponent = () => {
+  return (
+    <button
+      data-hook="hightlight-button"
+      className={styles.option}
+      onClick={() => highlightSelection()}
+    >
+      H
+    </button>
+  );
+};
+
+export default HighlightButton;

--- a/packages/text-selection-toolbar/web/src/UnhighlightButton.tsx
+++ b/packages/text-selection-toolbar/web/src/UnhighlightButton.tsx
@@ -1,0 +1,32 @@
+import React, { FunctionComponent } from 'react';
+import styles from '../statics/styles/viewer-inline-toolbar.rtlignore.scss';
+
+function unhighlight(node) {
+  if (node.nodeType === 1) {
+    const bg = node.style.backgroundColor;
+    if (bg === 'yellow') {
+      node.style.backgroundColor = '';
+    }
+  }
+
+  let child = node.firstChild;
+
+  while (child) {
+    unhighlight(child);
+    child = child.nextSibling;
+  }
+}
+
+const UnhighlightButton: FunctionComponent = () => {
+  return (
+    <button
+      data-hook="unhightlight-button"
+      className={styles.option}
+      onClick={() => unhighlight(document.body)}
+    >
+      <del>H</del>
+    </button>
+  );
+};
+
+export default UnhighlightButton;

--- a/packages/text-selection-toolbar/web/src/index.ts
+++ b/packages/text-selection-toolbar/web/src/index.ts
@@ -1,4 +1,6 @@
 import TextSelectionToolbar from './TextSelectionToolbar';
 import TwitterButton from './TwitterButton';
+import HighlightButton from './HighlightButton';
+import UnhighlightButton from './UnhighlightButton';
 
-export { TextSelectionToolbar, TwitterButton };
+export { TextSelectionToolbar, TwitterButton, HighlightButton, UnhighlightButton };


### PR DESCRIPTION
Current issues:

* Nodes are disconnected from editor once highlighted
* Unhighlight is global, removes all yellow backgrounds, could be made more specific.

<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
