### PR TITLE
[color-picker] fix: support non-colors colors in add new color modal

### DIFF
--- a/packages/plugin-commons/web/src/Components/ColorPicker/CustomColorPickerDialog.jsx
+++ b/packages/plugin-commons/web/src/Components/ColorPicker/CustomColorPickerDialog.jsx
@@ -12,7 +12,7 @@ class CustomColorPickerDialog extends Component {
     this.styles = mergeStyles({ styles, theme: props.theme });
     this.initialColor = props.color;
     this.state = {
-      color: props.color,
+      color: props.color[0] === '#' ? props.color : '#ffffff',
     };
     this.onCancel = this.onCancel.bind(this);
     this.onUpdate = this.onUpdate.bind(this);


### PR DESCRIPTION
<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
