### PR TITLE
[link] fix anchors href bug in editor, and set cursor: text in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
     Click to see more.
   </summary>
 
-  
+### :bug: Bug Fix
+- `link`
+  - [#2119](https://github.com/wix-incubator/rich-content/pull/2119) anchors issues in editor
 
 </details>
 <hr/>

--- a/packages/plugin-link/web/src/LinkViewer.jsx
+++ b/packages/plugin-link/web/src/LinkViewer.jsx
@@ -45,14 +45,16 @@ class LinkViewer extends Component {
       const { onClick } = settings;
       const { anchor, url } = componentData;
       onClick?.(event, componentData?.customData || this.getHref(url, anchor));
-      if (anchor && !isInEditor) {
-        event.preventDefault();
-        const anchorString = `viewer-${anchor}`;
-        const element = document.getElementById(anchorString);
-        addAnchorTagToUrl(anchorString);
-        anchorScroll(element);
+      if (anchor) {
+        event.stopPropagation(); // fix problem with wix platform, where it wouldn't scroll and sometimes jump to different page
+        if (!isInEditor) {
+          event.preventDefault();
+          const anchorString = `viewer-${anchor}`;
+          const element = document.getElementById(anchorString);
+          addAnchorTagToUrl(anchorString);
+          anchorScroll(element);
+        }
       }
-      event.stopPropagation(); // fix problem with wix platform, where it wouldn't scroll and sometimes jump to different page
     }
   };
 

--- a/packages/plugin-link/web/src/LinkViewer.jsx
+++ b/packages/plugin-link/web/src/LinkViewer.jsx
@@ -47,12 +47,12 @@ class LinkViewer extends Component {
       onClick?.(event, componentData?.customData || this.getHref(url, anchor));
       if (anchor && !isInEditor) {
         event.preventDefault();
-        event.stopPropagation(); // fix problem with wix platform, where it wouldn't scroll and sometimes jump to different page
         const anchorString = `viewer-${anchor}`;
         const element = document.getElementById(anchorString);
         addAnchorTagToUrl(anchorString);
         anchorScroll(element);
       }
+      event.stopPropagation(); // fix problem with wix platform, where it wouldn't scroll and sometimes jump to different page
     }
   };
 
@@ -74,7 +74,8 @@ class LinkViewer extends Component {
       target: this.getTarget(anchor, target, anchorTarget),
       rel: rel ? rel : relValue || 'noopener',
       className: classNames(this.styles.link, {
-        [this.styles.linkToAnchorInViewer]: anchor && !isInEditor,
+        [this.styles.linkInEditor]: isInEditor,
+        [this.styles.linkInViewer]: !isInEditor,
       }),
       onClick: this.handleClick,
     };

--- a/packages/plugin-link/web/statics/link-viewer.scss
+++ b/packages/plugin-link/web/statics/link-viewer.scss
@@ -5,7 +5,12 @@
   color: $ricos-link-color;
   @include ricosTypography('link', false);
 }
-.linkToAnchorInViewer {
+.linkInEditor{
+  &:hover {
+    cursor: text;
+  }
+}
+.linkInViewer {
   &:hover {
     cursor: pointer;
   }


### PR DESCRIPTION
- event.stopPropagation() when clicking on anchor in Editor.
- set cursor: text when hovering over link in Editor.