### PR TITLE
fix(editor/viewer): context re-render issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
     Click to see more.
   </summary>
 
+### :bug: Bug Fix
+- `editor`
+  - [#2193](https://github.com/wix/ricos/pull/2193) fix content re-render issue
+- `viewer`
+  - [#2193](https://github.com/wix/ricos/pull/2193) fix content re-render issue
 
 </details>
 

--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
@@ -167,7 +167,7 @@ interface State {
     isMobile: boolean;
     t?: TranslationFunction;
     containerWidth?: number;
-  };;
+  };
 }
 
 // experiment example code

--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
@@ -161,6 +161,13 @@ interface State {
   textToolbarType?: TextToolbarType;
   error?: string;
   readOnly: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  context: {
+    experiments?: AvailableExperiments;
+    isMobile: boolean;
+    t?: TranslationFunction;
+    containerWidth?: number;
+  };;
 }
 
 // experiment example code
@@ -221,11 +228,13 @@ class RichContentEditor extends Component<RichContentEditorProps, State> {
   constructor(props: RichContentEditorProps) {
     super(props);
     const initialEditorState = this.getInitialEditorState();
+    const { experiments, isMobile = false, t, width } = props;
     this.state = {
       editorState: initialEditorState,
       innerModal: null,
       toolbarsToIgnore: [],
       readOnly: false,
+      context: { experiments, isMobile, t, containerWidth: width },
     };
     this.refId = Math.floor(Math.random() * 9999);
 
@@ -945,14 +954,14 @@ class RichContentEditor extends Component<RichContentEditorProps, State> {
   setEditorWrapper = ref => ref && (this.editorWrapper = ref);
 
   render() {
-    const { onError, locale, direction, experiments, showToolbars = true, width } = this.props;
+    const { onError, locale, direction, showToolbars = true } = this.props;
     const { innerModal } = this.state;
     try {
       if (this.state.error) {
         onError(this.state.error);
         return null;
       }
-      const { isMobile = false, t } = this.props;
+      const { isMobile = false } = this.props;
       const { theme } = this.contextualData;
       const themeDesktopStyle = theme.desktop
         ? { [theme.desktop]: !isMobile && theme && theme.desktop }
@@ -962,7 +971,7 @@ class RichContentEditor extends Component<RichContentEditorProps, State> {
         ...themeDesktopStyle,
       });
       return (
-        <GlobalContext.Provider value={{ experiments, isMobile, t, containerWidth: width }}>
+        <GlobalContext.Provider value={this.state.context}>
           <Measure bounds onResize={this.onResize}>
             {({ measureRef }) => (
               <div

--- a/packages/viewer/web/src/RichContentViewer.tsx
+++ b/packages/viewer/web/src/RichContentViewer.tsx
@@ -69,7 +69,16 @@ export interface RichContentViewerProps {
 
 class RichContentViewer extends Component<
   RichContentViewerProps,
-  { raw?: RicosContent; error?: string }
+  {
+    raw?: RicosContent;
+    error?: string;
+    context: {
+      experiments?: AvailableExperiments;
+      isMobile: boolean;
+      t?: TranslationFunction;
+      containerWidth?: number;
+    };
+  }
 > {
   styles: Record<string, string>;
   typeMappers: PluginMapping;
@@ -92,7 +101,10 @@ class RichContentViewer extends Component<
     const styles = { ...viewerStyles, ...viewerAlignmentStyles, ...rtlStyle };
     this.styles = mergeStyles({ styles, theme: props.theme });
     this.typeMappers = combineMappers(props.typeMappers);
-    this.state = {};
+    const { experiments, isMobile = false, t, width } = props;
+    this.state = {
+      context: { experiments, isMobile, t, containerWidth: width },
+    };
   }
 
   static getInitialState = (props: RichContentViewerProps) => {
@@ -197,11 +209,7 @@ class RichContentViewer extends Component<
         inlineStyleMappers,
         locale,
         addAnchors,
-        isMobile = false,
-        t,
-        experiments,
         renderedInTable,
-        width,
       } = this.props;
       const wrapperClassName = classNames(styles.wrapper, {
         [styles.desktop]: !this.props.platform || this.props.platform === 'desktop',
@@ -240,7 +248,7 @@ class RichContentViewer extends Component<
       );
 
       return (
-        <GlobalContext.Provider value={{ experiments, isMobile, t, containerWidth: width }}>
+        <GlobalContext.Provider value={this.state.context}>
           <div className={wrapperClassName} dir={direction || getLangDir(locale)}>
             <div className={editorClassName}>{output}</div>
             <AccessibilityListener isMobile={this.props.isMobile} />


### PR DESCRIPTION
once image plugin consumed context, re-render happens which effected the editor state behavior in example app
Fix according to react context caveats -  https://reactjs.org/docs/context.html#caveats