### PR TITLE
[social-embed]fix: remove link settings button from embed inline toolbar

### DIFF
--- a/packages/plugin-commons/web/src/Base/toolbars/createAtomicPluginToolbar.jsx
+++ b/packages/plugin-commons/web/src/Base/toolbars/createAtomicPluginToolbar.jsx
@@ -288,12 +288,14 @@ export default function createAtomicPluginToolbar({
           );
         case BUTTONS.LINK_PREVIEW: {
           return (
-            <BlockLinkButton
-              {...baseLinkProps}
-              unchangedUrl
-              tooltipText={t('LinkPreview_Settings_Tooltip')}
-              icons={button.icons}
-            />
+            !this.state.componentData.html && (
+              <BlockLinkButton
+                {...baseLinkProps}
+                unchangedUrl
+                tooltipText={t('LinkPreview_Settings_Tooltip')}
+                icons={button.icons}
+              />
+            )
           );
         }
         case BUTTONS.DELETE: {


### PR DESCRIPTION
<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
