### PR TITLE
[link-preview]fix: remove space from bottom link preview plugin

### DIFF
--- a/packages/plugin-link-preview/web/lib/utils.ts
+++ b/packages/plugin-link-preview/web/lib/utils.ts
@@ -49,7 +49,7 @@ const addLinkPreview = async (
       provider_url,
     };
     const { newEditorState } = createBlock(withoutLinkBlock, data, LINK_PREVIEW_TYPE);
-    setEditorState(RichUtils.insertSoftNewline(newEditorState));
+    setEditorState(newEditorState);
   }
 };
 


### PR DESCRIPTION
<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
