### PR TITLE
[plugin-image] Avoid exception when image src missing

### DIFF
--- a/packages/plugin-image/web/src/image-viewer.tsx
+++ b/packages/plugin-image/web/src/image-viewer.tsx
@@ -159,7 +159,7 @@ class ImageViewer extends React.Component<ImageViewerProps, ImageViewerState> {
 
     let requiredWidth, requiredHeight;
     let imageSrcOpts = {};
-    const isPNG = /(.*)\.(png)$/.test(src.file_name);
+    const isPNG = /(.*)\.(png)$/.test(src?.file_name);
     /**
         PNG files can't reduce quality via Wix services and we want to avoid downloading a big png image that will affect performance.
       **/

--- a/packages/plugin-image/web/src/image-viewer.tsx
+++ b/packages/plugin-image/web/src/image-viewer.tsx
@@ -7,6 +7,7 @@ import {
   validate,
   isSSR,
   getImageSrc,
+  isPNG,
   WIX_MEDIA_DEFAULT,
   anchorScroll,
   addAnchorTagToUrl,
@@ -159,11 +160,14 @@ class ImageViewer extends React.Component<ImageViewerProps, ImageViewerState> {
 
     let requiredWidth, requiredHeight;
     let imageSrcOpts = {};
-    const isPNG = /(.*)\.(png)$/.test(src?.file_name);
     /**
         PNG files can't reduce quality via Wix services and we want to avoid downloading a big png image that will affect performance.
       **/
-    if (!this.props.isMobile && !isPNG && this.context.experiments?.useQualityPreload?.enabled) {
+    if (
+      !this.props.isMobile &&
+      !isPNG(src) &&
+      this.context.experiments?.useQualityPreload?.enabled
+    ) {
       const {
         componentData: {
           config: { alignment, width },
@@ -175,6 +179,7 @@ class ImageViewer extends React.Component<ImageViewerProps, ImageViewerState> {
         ...(usePredefinedWidth && { requiredWidth: 300 }),
       };
     }
+
     imageUrl.preload = getImageSrc(src, helpers?.getImageUrl, imageSrcOpts);
     if (seoMode) {
       requiredWidth = src?.width && Math.min(src.width, SEO_IMAGE_WIDTH);

--- a/packages/ricos-content/web/src/imageUtils.ts
+++ b/packages/ricos-content/web/src/imageUtils.ts
@@ -122,4 +122,11 @@ const getImageSrc = (
   return src;
 };
 
-export { getImageSrc, DEFAULT as WIX_MEDIA_DEFAULT };
+const isPNG = (src?: ComponentData['src']): boolean => {
+  if (!src || !src.file_name) {
+    return false;
+  }
+  return /(.*)\.(png)$/.test(src.file_name);
+};
+
+export { isPNG, getImageSrc, DEFAULT as WIX_MEDIA_DEFAULT };

--- a/packages/ricos-content/web/src/index.ts
+++ b/packages/ricos-content/web/src/index.ts
@@ -16,6 +16,6 @@ export { isContentStateEmpty } from './contentStateUtils/contentStateUtils';
 
 export { createContent } from './contentStateUtils/createContent';
 
-export { getImageSrc, WIX_MEDIA_DEFAULT } from './imageUtils';
+export { isPNG, getImageSrc, WIX_MEDIA_DEFAULT } from './imageUtils';
 
 export { compare } from './comparision/compare';


### PR DESCRIPTION
### Issue
In some cases Ricos viewer crashes (along with the rest of the app) when image source in image plugin is undefined. Rest of the code has checks for that, but `isPNG` regex match does not.

### Solution
Added conditional check to avoid that

### Additional info
Yes, it is a one symbol PR :) After this check regex function get `undefined`, and returns false. It is correct, since `undefined` is definitely not a PNG. Why `src` is undefined there is another question, but in any case, it should not crash here.