### PR TITLE
[editor] fix: toolbar shortcuts - focus on first button and show outline

### DIFF
--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
@@ -670,7 +670,7 @@ class RichContentEditor extends Component<RichContentEditorProps, State> {
       buttonToFocus.focus();
       setTimeout(() => {
         // fix bug - selection of text with atomic blocks
-        if (toolbar !== document.activeElement) {
+        if (buttonToFocus !== document.activeElement) {
           buttonToFocus.focus();
         }
       });

--- a/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
+++ b/packages/editor/web/src/RichContentEditor/RichContentEditor.tsx
@@ -665,13 +665,16 @@ class RichContentEditor extends Component<RichContentEditorProps, State> {
         .getBlockForKey(focusedAtomicPluginKey);
     }
     const toolbar = pluginToolbar || formattingToolbar;
-    toolbar && toolbar.focus();
-    setTimeout(() => {
-      // fix bug - selection of text with atomic blocks
-      if (toolbar !== document.activeElement) {
-        toolbar && toolbar.focus();
-      }
-    });
+    if (toolbar) {
+      const buttonToFocus = toolbar.querySelectorAll('Button')[0] as HTMLElement;
+      buttonToFocus.focus();
+      setTimeout(() => {
+        // fix bug - selection of text with atomic blocks
+        if (toolbar !== document.activeElement) {
+          buttonToFocus.focus();
+        }
+      });
+    }
   };
 
   getHeadings = config => {

--- a/packages/editor/web/statics/styles/inline-toolbar.rtlignore.scss
+++ b/packages/editor/web/statics/styles/inline-toolbar.rtlignore.scss
@@ -22,6 +22,10 @@ $borderRadius: 6px;
 .inlineToolbar_buttons {
   display: flex;
   height: 50px;
+  & button:focus {
+    outline: 5px auto Highlight !important;
+    outline: 5px auto -webkit-focus-ring-color !important;
+  }
 }
 
 .inlineToolbar_overrideContent {

--- a/packages/plugin-commons/web/statics/styles/plugin-toolbar.scss
+++ b/packages/plugin-commons/web/statics/styles/plugin-toolbar.scss
@@ -34,6 +34,11 @@ $MARGIN_LEFT: 10px;
     display: none;
     width: 0 !important;
   }
+
+  & button:focus {
+    outline: 5px auto Highlight !important;
+    outline: 5px auto -webkit-focus-ring-color !important;
+  }
 }
 
 .pluginToolbar_panel {


### PR DESCRIPTION
<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
