### PR TITLE
Allow custom logic for scrolling to anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,16 @@
     Changes that have landed in master but are not yet released.
     Click to see more.
   </summary>
-  
+
   ### :bug: Bug Fix
   - `link`
     - [#2435](https://github.com/wix-incubator/rich-content/pull/2435) static toolbar link popup styles fixed
   - `general`
     - [#2435](https://github.com/wix-incubator/rich-content/pull/2435) ClickOutside for inline popups supports drag out
+
+  ### :rocket: New Feature
+  - `plugin-link`
+    - [#2468](https://github.com/wix/ricos/pull/2468) add optional `customAnchorScroll` function as alternative to built-in scrolling and url replacement
 
 </details>
 <hr/>
@@ -50,7 +54,7 @@
   - [#2397](https://github.com/wix/ricos/pull/2397) scroll to plugin added out of view
 - `gallery`
   - [#2402](https://github.com/wix-incubator/rich-content/pull/2402) galleries on horizontal `scrollDirection` have height and arrows
-  
+
 ### :house: Internal
 - `e2e`
   - [#2381](https://github.com/wix/ricos/pull/2381) undo redo tests improvement
@@ -88,7 +92,7 @@
   - [#2398](https://github.com/wix-incubator/rich-content/pull/2398)  Avoid exception when image src missing
 - `editor`
   - [#2385](https://github.com/wix-incubator/rich-content/pull/2385) toolbar shortcuts in mac & windows
-  
+
 ## 8.30.3 (April 22, 2021)
 ### :bug: Bug Fix
 - `image`

--- a/examples/main/shared/editor/EditorPlugins.tsx
+++ b/examples/main/shared/editor/EditorPlugins.tsx
@@ -623,6 +623,12 @@ const config: RichContentEditorProps['config'] = {
     //     },
     //   },
     // },
+    // customAnchorScroll: (event, anchor) => {
+    //   const anchorString = `viewer-${anchor}`;
+    //   const element = document.getElementById(anchorString);
+    //   // ... do custom logic here
+    //   element.scrollIntoView({ behavior: 'smooth' });
+    // },
   },
   [CODE_BLOCK_TYPE]: {
     // toolbar: {

--- a/packages/plugin-link/web/src/LinkViewer.jsx
+++ b/packages/plugin-link/web/src/LinkViewer.jsx
@@ -43,7 +43,7 @@ class LinkViewer extends Component {
     const { componentData, isInEditor, config, helpers } = this.props;
     const settings = config?.[LINK_TYPE];
     if (settings) {
-      const { onClick } = settings;
+      const { onClick, customAnchorScroll } = settings;
       const { anchor, url } = componentData;
       helpers?.onViewerAction?.(LINK_TYPE, 'Click', componentData);
       onClick?.(event, componentData?.customData || this.getHref(url, anchor));
@@ -51,10 +51,14 @@ class LinkViewer extends Component {
         event.stopPropagation(); // fix problem with wix platform, where it wouldn't scroll and sometimes jump to different page
         if (!isInEditor) {
           event.preventDefault();
-          const anchorString = `viewer-${anchor}`;
-          const element = document.getElementById(anchorString);
-          addAnchorTagToUrl(anchorString);
-          anchorScroll(element);
+          if (customAnchorScroll) {
+            customAnchorScroll(event, anchor);
+          } else {
+            const anchorString = `viewer-${anchor}`;
+            const element = document.getElementById(anchorString);
+            addAnchorTagToUrl(anchorString);
+            anchorScroll(element);
+          }
         }
       }
     }


### PR DESCRIPTION
We're using the plugin-link in our editors and views to allow scrolling to anchors within post but our headers aren't the same sizes as the standard wix headers.

We'd like to have a config option `customAnchorScroll` for the LINK plugin that would be called instead of the built in `anchorScroll` and `addAnchorTagToUrl` that's fired in `LinkViewer`'s `handleClick`. That way we can calculate a better set of margins in order to scroll to the right place (and do other custom logic with the url).
