### PR TITLE
Get rid of direct usage of i18next in plugins

### DIFF
--- a/packages/common/web/src/Utils/withI18n.tsx
+++ b/packages/common/web/src/Utils/withI18n.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent, Ref, ComponentType } from 'react';
-import { I18nextProvider, translate } from 'react-i18next';
+import { I18nextProvider, translate, Trans } from 'react-i18next';
 import i18n from './i18n';
 import createHocName from './createHocName';
 import { LocaleResource } from '../types';
@@ -86,3 +86,5 @@ export default <T, P>(
 
   return React.forwardRef<T, P>((props, ref) => <I18nWrapper {...props} forwardedRef={ref} />);
 };
+
+export { translate, Trans };

--- a/packages/common/web/src/index.ts
+++ b/packages/common/web/src/index.ts
@@ -5,7 +5,7 @@ export { default as AccessibilityListener } from './Components/AccessibilityList
 export { default as ViewportRenderer } from './Components/ViewportRenderer';
 
 // Utils
-export { default as withI18n } from './Utils/withI18n';
+export { default as withI18n, translate, Trans } from './Utils/withI18n';
 export { default as createHocName } from './Utils/createHocName';
 export {
   sizeClassName,

--- a/packages/editor/web/src/RichContentEditor/Components/ErrorMessage.jsx
+++ b/packages/editor/web/src/RichContentEditor/Components/ErrorMessage.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MediaUploadErrorKey } from 'wix-rich-content-common';
-import { Trans } from 'react-i18next';
+import { MediaUploadErrorKey, Trans } from 'wix-rich-content-common';
 import Toast from './Toast';
 
 const errorMap = {

--- a/packages/plugin-divider/web/src/toolbar/insert-buttons.tsx
+++ b/packages/plugin-divider/web/src/toolbar/insert-buttons.tsx
@@ -1,8 +1,7 @@
 import InsertPluginIcon from '../icons/InsertPluginIcon';
 import { DEFAULTS } from '../defaults';
 import { TOOLBARS, BUTTON_TYPES, INSERT_PLUGIN_BUTTONS } from 'wix-rich-content-editor-common';
-import { CreateInsertButtons } from 'wix-rich-content-common';
-import { TranslationFunction } from 'react-i18next';
+import { CreateInsertButtons, TranslationFunction } from 'wix-rich-content-common';
 import { DividerPluginEditorConfig } from '../types';
 
 export const createInsertButtons: CreateInsertButtons = ({

--- a/packages/plugin-gallery/web/src/components/layout-controls-section.js
+++ b/packages/plugin-gallery/web/src/components/layout-controls-section.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-// import { translate } from 'react-i18next';
 import { mergeStyles } from 'wix-rich-content-common';
 import { SettingsSection } from 'wix-rich-content-plugin-commons';
 import { decorateComponentWithProps } from 'wix-rich-content-editor-common';

--- a/packages/plugin-html/web/src/toolbar/inline-buttons.ts
+++ b/packages/plugin-html/web/src/toolbar/inline-buttons.ts
@@ -1,4 +1,3 @@
-import { translate } from 'react-i18next';
 import {
   BUTTONS,
   SizeSmallLeftIcon,
@@ -17,7 +16,7 @@ import {
   SRC_TYPE_URL,
 } from '../defaults';
 import EditPanel from './HtmlEditPanel';
-import { CreateInlineButtons, GetEditorBounds } from 'wix-rich-content-common';
+import { CreateInlineButtons, GetEditorBounds, translate } from 'wix-rich-content-common';
 import { HtmlPluginEditorConfig } from '../types';
 
 const getAlignmentButtonPropsFn = getEditorBounds => ({ componentData }) => {


### PR DESCRIPTION
<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
