### PR TITLE
[*] remove string.matchAll to work in safari 12 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
     Click to see more.
   </summary>
 
+- `*`
+  - [#2749](https://github.com/wix/ricos/pull/2749) remove string.matchAll to work in safari 12
 
 </details>
 <hr/>

--- a/packages/common/web/src/draftDecorators/createJustificationFixDecorator.tsx
+++ b/packages/common/web/src/draftDecorators/createJustificationFixDecorator.tsx
@@ -44,11 +44,13 @@ export default function createJustificationFixDecorator(): DraftDecorator {
     if (!isSSR() && !isChrome() && isTextJustified(contentBlock)) {
       const regex = /\s[^\s]/g;
       const str = contentBlock.getText();
-      Array.from(str.matchAll(regex), (match: { index: number }) => match.index).forEach(i => {
-        if (!isInLink(i, contentBlock, contentState)) {
-          callback(i, i + 1);
+      let match;
+      // eslint-disable-next-line fp/no-loops
+      while ((match = regex.exec(str)) !== null) {
+        if (!isInLink(match.index, contentBlock, contentState)) {
+          callback(match.index, match.index + 1);
         }
-      });
+      }
     }
   };
 

--- a/packages/ricos-content/web/src/converters/draft/toDraft/decorationParsers.ts
+++ b/packages/ricos-content/web/src/converters/draft/toDraft/decorationParsers.ts
@@ -159,19 +159,22 @@ export const getParagraphNode = (node: Node) => {
 const convertDecorationTypes = (decorations: Decoration[]): DraftTypedDecoration[] =>
   decorations.flatMap(decoration => pipe(decoration, toDraftDecorationType, splitColorDecoration));
 
-const createEmojiDecorations = (text: string) =>
-  Array.from(text.matchAll(emojiRegex)).flatMap(({ 0: emojiUnicode, index: start }) => {
-    if (start) {
-      const decoration: RangedDecoration = {
-        type: 'EMOJI_TYPE',
-        emojiData: { emojiUnicode },
-        start,
-        end: start + Array.from(emojiUnicode).length,
-      };
-      return decoration;
-    }
-    return [];
-  });
+const createEmojiDecorations = (text: string) => {
+  const result: RangedDecoration[] = [];
+  let match;
+  // eslint-disable-next-line fp/no-loops
+  while ((match = emojiRegex.exec(text)) !== null) {
+    const { 0: emojiUnicode, index: start } = match;
+    const decoration: RangedDecoration = {
+      type: 'EMOJI_TYPE',
+      emojiData: { emojiUnicode },
+      start,
+      end: start + Array.from(emojiUnicode).length,
+    };
+    result.push(decoration);
+  }
+  return result;
+};
 
 const toDraftDecorationType = (decoration: Decoration): DraftTypedDecoration => ({
   ...decoration,


### PR DESCRIPTION
<!--
Hi, thank you for contributing!

Please make sure you have updated the changelog 'Unreleased' section
-->
